### PR TITLE
Increase query_two precision

### DIFF
--- a/puppy_query.py
+++ b/puppy_query.py
@@ -31,7 +31,10 @@ def query_one():
 def query_two():
     """Query all of the puppies that are less than 6 months old organized by the youngest first"""
     today = datetime.date.today()
-    sixMonthsAgo = today - datetime.timedelta(days = 365 / 2)
+    if passesLeapDay(today):
+        sixMonthsAgo = today - datetime.timedelta(days = 183)
+    else:
+        sixMonthsAgo = today - datetime.timedelta(days = 182)
     result = session.query(Puppy.name, Puppy.dateOfBirth)\
         .filter(Puppy.dateOfBirth >= sixMonthsAgo)\
         .order_by(Puppy.dateOfBirth.desc())
@@ -53,7 +56,33 @@ def query_four():
     for item in result:
         print item[0].id, item[0].name, item[1]
 
-
+# Helper Methods
+def passesLeapDay(today):
+    """
+    Returns true if most recent February 29th occured after or exactly 183 days ago (366 / 2)
+    """
+    thisYear = today.timetuple()[0]
+    if isLeapYear(thisYear):
+        sixMonthsAgo = today - datetime.timedelta(days = 183)
+        leapDay = datetime.date(thisYear, 2, 29)
+        return leapDay >= sixMonthsAgo
+    else:
+        return False
+        
+def isLeapYear(thisYear):
+    """
+    Returns true iff the current year is a leap year.
+    Implemented according to logic at https://en.wikipedia.org/wiki/Leap_year#Algorithm
+    """
+    if thisYear % 4 != 0:
+        return False
+    elif thisYear % 100 != 0:
+        return True
+    elif thisYear % 400 != 0:
+        return False
+    else:
+        return True
+        
 # query_one()
 # query_two()
 # query_three()

--- a/puppy_query.py
+++ b/puppy_query.py
@@ -31,13 +31,14 @@ def query_one():
 def query_two():
     """Query all of the puppies that are less than 6 months old organized by the youngest first"""
     today = datetime.date.today()
-    result = session.query(Puppy.name, Puppy.dateOfBirth).order_by(Puppy.dateOfBirth.desc()).all()
+    sixMonthsAgo = today - datetime.timedelta(days = 365 / 2)
+    result = session.query(Puppy.name, Puppy.dateOfBirth)\
+        .filter(Puppy.dateOfBirth >= sixMonthsAgo)\
+        .order_by(Puppy.dateOfBirth.desc())
 
     # print the result with puppy name and dob
     for item in result:
-        puppy_months = diff_month(today, item[1])
-        if puppy_months < 6:
-            print "{name}: {months}".format(name=item[0], months=puppy_months)
+        print "{name}: {dob}".format(name=item[0], dob=item[1])
 
 def query_three():
     """Query all puppies by ascending weight"""
@@ -52,12 +53,6 @@ def query_four():
     for item in result:
         print item[0].id, item[0].name, item[1]
 
-
-# Helpers methods
-def diff_month(d1, d2):
-    """calculate number of months by counting day from today"""
-    delta = d1 - d2
-    return delta.days / 30
 
 # query_one()
 # query_two()


### PR DESCRIPTION
(1) query_two would fail to return some puppies which were less than 6 months old.
(2) Additionally, the query was constructed such that all puppies were returned, regardless of whether they were less than 6 months old.
(3) Additionally, date of birth was not printed, even though code comments suggest this was desired.

Assuming a 365-day year, the "halves" of the year are 183 days and 182 days.  Accordingly, anything 182 days ago is minimally less than 6 months ago.

Thus:
(1) Replace 30-day month assumption with the assumption that 6 months ago was 182 days ago.  Delete diff_month() helper method as it is no longer used.
(2) Implement 182-day assumption in query filtering itself, rather than after query while iterating through results.
(3) Change {month}, ... month=diff_month(today, item[1]) to {dob}, ... dob=item[1].  This has the result of changing the output to something that is more easily verified as being within the desired time range.

Assuming a 366-day year, the halves are 183 days each. Accordingly, it's possible to further increase the precision of this query by checking whether this or last year was a leap year (that is, whether this year  % 4 == 0 or last year % 4 == 0), then replacing the above 182-day assumption with a 183-day assumption.  That may be a bit more code than is desired for this query though.